### PR TITLE
Fix Huawei VRP display_version

### DIFF
--- a/ntc_templates/templates/huawei_vrp_display_version.textfsm
+++ b/ntc_templates/templates/huawei_vrp_display_version.textfsm
@@ -6,4 +6,4 @@ Value UPTIME (.+)
 
 Start
   ^.*software,\s+Version\s+${VRP_VERSION}\s+\(${PRODUCT_VERSION}\)
-  ^HUAWEI\s+${MODEL}\s+uptime\s+is\s+${UPTIME}$$
+  ^(HUAWEI|Huawei)\s+${MODEL}\s+uptime\s+is\s+${UPTIME}$$

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version3.raw
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version3.raw
@@ -1,0 +1,26 @@
+Huawei Versatile Routing Platform Software
+VRP (R) software, Version 5.170 (AR6280 V300R019C10SPC300)
+Copyright (C) 2011-2020 HUAWEI TECH CO., LTD
+Huawei AR6280 Router uptime is 60 weeks, 4 days, 11 hours, 20 minutes
+BKP 0 version information:
+1. PCB      Version  : AR01BAK2B VER.A
+2. If Supporting PoE : Yes
+3. Board    Type     : AR6280
+4. MPU Slot Quantity : 1
+5. LPU Slot Quantity : 8
+
+MPU 11(Master) : uptime is 60 weeks, 4 days, 11 hours, 19 minutes
+SDRAM Memory Size    : 8192    M bytes
+Flash 0 Memory Size  : 2048    M bytes
+Flash 1 Memory Size  : 32      M bytes
+MPU version information :
+1. PCB      Version  : SRU-400H VER.A
+2. MAB      Version  : 1
+3. Board    Type     : SRU-400H
+4. CPLD0    Version  : 124
+5. BootROM  Version  : 1
+
+FAN version information :
+1. PCB      Version  : AR01DF05A VER.A
+2. Board    Type     : FAN
+3. Software Version  : 108

--- a/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
+++ b/tests/huawei_vrp/display_version/huawei_vrp_display_version3.yml
@@ -1,0 +1,6 @@
+---
+parsed_sample:
+  - vrp_version: "5.170"
+    product_version: "AR6280 V300R019C10SPC300"
+    model: "AR6280 Router"
+    uptime: "60 weeks, 4 days, 11 hours, 20 minutes"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT
- Template: huawei_vrp_display_version.textfsm
- OS: Huawei VRP
- Command: display version

##### SUMMARY
Some platforms use `Huawei` instead of `HUAWEI` in their model information. This PR includes `Huawei` to the start of the model information, and relevant test

